### PR TITLE
Several fixes

### DIFF
--- a/bin/workling_client
+++ b/bin/workling_client
@@ -3,10 +3,12 @@ require 'rubygems'
 require 'daemons'
 require File.join(File.dirname(__FILE__), '../lib/workling_daemon')
 
+rails_root = File.exists?('./workling.gemspec') ? File.join(Dir.pwd, '../../../') : Dir.pwd
+
 daemon_options = {
   :app_name   => "workling",
   :dir_mode   => :normal,
-  :dir        => File.join(Dir.pwd, 'log'),
+  :dir        => File.join(rails_root, 'log'),
   :log_output => true,
   :multiple   => false,
   :backtrace  => true,
@@ -17,7 +19,7 @@ workling_options = {
   :client_class => "memcache_queue",
   :invoker_class => "threaded_poller",
   :routing_class => "class_and_method",
-  :rails_root => Dir.pwd,
+  :rails_root => rails_root,
   :load_path => ['app/workers/**/*.rb', 'vendor/**/**/app/workers/*.rb'],
   :rails_env => (ENV['RAILS_ENV'] || "development").dup,
   :no_rails => false

--- a/bin/workling_client
+++ b/bin/workling_client
@@ -18,7 +18,7 @@ workling_options = {
   :invoker_class => "threaded_poller",
   :routing_class => "class_and_method",
   :rails_root => Dir.pwd,
-  :load_path => ['app/workers/**/*.rb'],
+  :load_path => ['app/workers/**/*.rb', 'vendor/**/**/app/workers/*.rb'],
   :rails_env => (ENV['RAILS_ENV'] || "development").dup,
   :no_rails => false
 }.merge(WorklingDaemon.parse_workling_options(ARGV))


### PR DESCRIPTION
= Workers directories.

We have started to use Workling to off-load jobs from requests. Currently we're still prototyping our off-request architectures. So far, Workling is the best we have found.

We needed however, to implement our workers in the plugin dir. This patch simply adds this by default.

TODO: Honor config.plugin.

= Rails root

The workling_client now checks whether or not to use Dir.pwd as the rails_root.

= Fixing SQS Client

The require sentences should be in self.load. Added a simple implementation for self.installed?
